### PR TITLE
Update ShortcutBadger to 1.1.16

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,5 +34,5 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'me.leolin:ShortcutBadger:1.1.10@aar'
+    compile 'me.leolin:ShortcutBadger:1.1.16@aar'
 }


### PR DESCRIPTION
Update ShortcutBadger package to 1.1.16 to take advantage of the latest updates since 1.1.10