### PR TITLE
Fix RN 0.47 breaking change

### DIFF
--- a/android/src/main/java/me/jhen/react/BadgePackage.java
+++ b/android/src/main/java/me/jhen/react/BadgePackage.java
@@ -19,7 +19,7 @@ public class BadgePackage implements ReactPackage {
     return modules;
   }
 
-  @Override
+  // Deprecated in RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
Remove Override to enable compiling with RN 0.47. Change is backwards compatible