### PR TITLE
Fixed Gradle setup

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,22 +1,31 @@
 buildscript {
-    repositories {
-        jcenter()
-    }
+    // The Android Gradle plugin is only required when opening the android folder stand-alone.
+    // This avoids unnecessary downloads and potential conflicts when the library is included as a
+    // module dependency in an application project.
+    if (project == rootProject) {
+        repositories {
+            google()
+            jcenter()
+        }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        dependencies {
+            classpath("com.android.tools.build:gradle:3.6.3")
+        }
     }
 }
 
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    compileSdkVersion safeExtGet('compileSdkVersion', 29)
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 27
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 29)
         versionCode 1
         versionName "1.0"
     }
@@ -30,6 +39,8 @@ repositories {
     maven {
         url "$projectDir/../../react-native/android"
     }
+    google()
+    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
# Summary

- Load Android Gradle Plugin conditionally

This wraps the Android Gradle plugin dependency in the buildscripts section of android/build.gradle in a conditional:

```
if (project == rootProject) {
    // ... (dependency here)
}
```

The Android Gradle plugin is only required when opening the project stand-alone, not when it is included as a dependency. By doing this, the project opens correctly in Android Studio, and it can also be consumed as a native module dependency from an application project without affecting the app project (avoiding unnecessary downloads/conflicts/etc).

for more info, you can refer to [this thread](https://github.com/facebook/react-native/pull/25569) and especially [this comment.](https://github.com/facebook/react-native/pull/25569#issuecomment-532504277)

- set root project's Gradle config instead of hardcoded configs (with fallback option)

- remove `buildToolsVersion` config, because it's no longer necessary with newer versions of the Android Gradle plugin.

## Test Plan

Suppose you use this library on a project that has a different AGP version than this library's AGP version and the latter one is not installed on the OS. by this change, the library's AGP will not download during the build process (which it shouldn't be)

### What's required for testing (prerequisites)?

An OS that has not installed the Android Gradle Plugin version that this library already using.

### What are the steps to reproduce (after prerequisites)?

Just import this library in a project and run it on an Android emulator or a real device

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
